### PR TITLE
feat: Add JSON repair functionality to JSON utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@nuxtjs/tailwindcss": "^6.12.2",
+    "jsonrepair": "^3.8.1",
     "nuxt": "^3.13.2",
     "nuxt-icon": "^1.0.0-beta.7",
     "qrcode-vue3": "^1.7.1",

--- a/pages/utils/json.vue
+++ b/pages/utils/json.vue
@@ -57,6 +57,11 @@
           <Icon name="mdi:format-quote-open" class="w-5 h-5 mr-2" />
           Unescape
         </button>
+        <button @click="repairJSON"
+          class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 flex items-center">
+          <Icon name="mdi:wrench" class="w-5 h-5 mr-2" />
+          Repair
+        </button>
       </div>
 
       <!-- Error message -->
@@ -73,6 +78,8 @@
 </template>
 
 <script setup>
+import { jsonrepair } from 'jsonrepair'
+
 const jsonInput = ref('')
 const hasError = ref(false)
 const errorMessage = ref('')
@@ -318,6 +325,33 @@ const unescapeJSON = () => {
   } catch (e) {
     hasError.value = true
     errorMessage.value = e.message
+    errorLocation.value = parseErrorPosition(e)
+    updateHighlighting(errorLocation.value)
+  }
+}
+
+const repairJSON = () => {
+  try {
+    if (!jsonInput.value.trim()) {
+      return
+    }
+
+    // Attempt to repair the malformed JSON
+    const repaired = jsonrepair(jsonInput.value)
+    jsonInput.value = repaired
+    
+    hasError.value = false
+    errorMessage.value = ''
+    showSuccess.value = true
+    errorLocation.value = { line: 0, column: 0 }
+    updateHighlighting(null)
+
+    setTimeout(() => {
+      showSuccess.value = false
+    }, 3000)
+  } catch (e) {
+    hasError.value = true
+    errorMessage.value = `Repair failed: ${e.message}`
     errorLocation.value = parseErrorPosition(e)
     updateHighlighting(errorLocation.value)
   }


### PR DESCRIPTION
This PR adds comprehensive JSON repair functionality to the existing JSON utility tool.

## Changes
- Added `jsonrepair` dependency to package.json
- Implemented repairJSON function in json.vue utility
- Added red "Repair" button with wrench icon to UI
- Integrated with existing error handling and success messaging

## Features Supported
- Python dict strings (single quotes, None/True/False constants)
- Malformed JSON from LLM output
- Missing quotes around keys
- Missing commas and closing brackets
- Repair truncated JSON
- Replace single quotes with double quotes
- Handle special quote characters and whitespace
- Convert Python constants to JSON equivalents
- Strip trailing commas, comments, JSONP notation
- Handle MongoDB data types
- Concatenate split strings
- Transform newline-delimited JSON into valid arrays

Resolves #13

Generated with [Claude Code](https://claude.ai/code)